### PR TITLE
Change from STKAudioKit_STK to STKAudioKit_Stk

### DIFF
--- a/Sources/Stk/StkBundleHelper.mm
+++ b/Sources/Stk/StkBundleHelper.mm
@@ -9,7 +9,7 @@
     // XXX: We would like to just use SWIFTPM_MODULE_BUNDLE but it breaks CI.
     //      Instead copy the code from the SPM-generated resource_bundle_accessor.m
 
-    NSString *bundleName = @"STKAudioKit_STK";
+    NSString *bundleName = @"STKAudioKit_Stk";
 
     NSArray<NSURL*> *candidates = @[
         NSBundle.mainBundle.resourceURL,


### PR DESCRIPTION
Using STKAudioKit_STK in this case to find the location of the bundle results in an error as the path cannot be found. The module will be found correctly if the path includes STKAudioKit_Stk. 


