### PR TITLE
Build DocC documentation with `xcodebuild` rather than `swift build`.

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,5 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [STKAudioKit]
+    - platform: macos-xcodebuild
+      documentation_targets: [STKAudioKit]


### PR DESCRIPTION
See explanation in [this comment](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1992#issuecomment-1226613012).